### PR TITLE
Some robustness on creation of invoices

### DIFF
--- a/account/account.py
+++ b/account/account.py
@@ -69,7 +69,7 @@ class account_invoice(osv.osv):
         partner_id = vals.get('partner_id', False)
         journal_obj = self.pool['account.journal']
         partner_obj = self.pool['res.partner']
-        if journal_obj.browse(cr, uid, journal_id, context).e_invoice:
+        if journal_id and partner_id and journal_obj.browse(cr, uid, journal_id, context).e_invoice:
             partner = partner_obj.browse(cr, uid, partner_id, context)
             if not partner.ipa_code:
                 raise osv.except_osv(


### PR DESCRIPTION
When creating an invoice from any wizard, in case no journal is specified,  the following error occurs:

```
  File "/usr/lib/python2.6/site-packages/openerp/addons/l10n_it_e_invoice/account/account.py", line 72, in create
    if journal_obj.browse(cr, uid, journal_id, context).e_invoice:
  File "/usr/lib/python2.6/site-packages/openerp/osv/orm.py", line 503, in __getattr__
    return self[name]
  File "/usr/lib/python2.6/site-packages/openerp/osv/orm.py", line 406, in __getitem__
    field_values = self._table.read(self._cr, self._uid, ids, field_names, context=self._context, load="_classic_write")
  File "/usr/lib/python2.6/site-packages/openerp/osv/orm.py", line 3718, in read
    result = self._read_flat(cr, user, select, fields, context, load)
  File "/usr/lib/python2.6/site-packages/openerp/osv/orm.py", line 3772, in _read_flat
    cr.execute(query, [tuple(sub_ids)] + rule_params)
  File "/usr/lib/python2.6/site-packages/openerp/sql_db.py", line 161, in wrapper
    return f(self, *args, **kwargs)
  File "/usr/lib/python2.6/site-packages/openerp/sql_db.py", line 226, in execute
    res = self._obj.execute(query, params)
ProgrammingError: ERRORE:  l'operatore non esiste: integer = boolean
RIGA 1: ...d FROM "account_journal" WHERE account_journal.id IN (false)...
                                                             ^
NOTA: Nessun operatore trovato con nome e tipi di argomenti forniti. Potrebbe essere necessario convertire i tipi esplicitamente.
```

This patch fixes such error.
