### PR TITLE
Bug fixing and code enhancement for 'finalize_invoice_move_lines' function

### DIFF
--- a/model/account.py
+++ b/model/account.py
@@ -349,7 +349,7 @@ firmata digitalmente della fattura XML PA in data \
                 new_line.update({'debit': amount_vat})
             vat_line = {}
             for line in move_lines:
-                if ('credit' in line[2]  and line[2]['credit'] == amount_vat and self.type == 'out_invoice') or ('debit' in line[2]  and line[2]['debit'] == amount_vat and self.type == 'out_refund'):
+                if ('credit' in line[2]  and abs(line[2]['credit'] - amount_vat) < 0.00001 and self.type == 'out_invoice') or ('debit' in line[2]  and abs(line[2]['debit'] - amount_vat) < 0.00001 and self.type == 'out_refund'):
                     vat_line = {
                         'name': 'IVA - Split Payment',
                         'account_id': line[2]['account_id'],

--- a/model/account.py
+++ b/model/account.py
@@ -323,7 +323,7 @@ firmata digitalmente della fattura XML PA in data \
     @api.multi
     def finalize_invoice_move_lines(self, move_lines):
         # manage of split_payment
-        super(AccountInvoice, self).finalize_invoice_move_lines(move_lines)
+        move_lines = super(AccountInvoice, self).finalize_invoice_move_lines(move_lines)
         # modify some data in move lines
         if self.type == 'out_invoice' or self.type == 'out_refund':
             journal = self.journal_id
@@ -349,8 +349,7 @@ firmata digitalmente della fattura XML PA in data \
                 new_line.update({'debit': amount_vat})
             vat_line = {}
             for line in move_lines:
-                if 'credit' in line[2] \
-                        and line[2]['credit'] == amount_vat:
+                if ('credit' in line[2]  and line[2]['credit'] == amount_vat and self.type == 'out_invoice') or ('debit' in line[2]  and line[2]['debit'] == amount_vat and self.type == 'out_refund'):
                     vat_line = {
                         'name': 'IVA - Split Payment',
                         'account_id': line[2]['account_id'],


### PR DESCRIPTION
I propose the following changes in the method 'finalize_invoice_move_lines':

1) Reinserting the method in its own inheritance path: calling the parent class function (which could modify the value of the variable 'move_lines') and then using the old value of 'move_lines' could cause errors due to data inconsistency;

2) Enhancing the check for what account move line (referencing to the tax) we have to divert: current version works well only for 'out_invoice' account moves (which have correctly the tax amount value on the 'credit' column) not for 'out_refund' account moves (which differently have the tax amount value on the 'debit' column). Actually, trying to validate an 'out_invoice' account move, linked to an 'e_invoice' journal, resolves in an unmanaged exception (trying to create an object 'account.move.line' without the required field 'account_id').

3) Changing the way we compare float numbers. When comparing float number data is possible that the condition 'a == b' doesn't give the attended result, probably due to the underlaying way the programming language and the OS manage float types. Actually it happened to us trying to validate an invoice with amoun_tax = 366.15; In that case, the condition 366.15 == 366.15 returned False.
